### PR TITLE
Fix for folder name with whitespace characters

### DIFF
--- a/MirrorFolders.py
+++ b/MirrorFolders.py
@@ -41,7 +41,7 @@ class BatchFile:
     def writeBatchFile(self, batchfilename, source, destination):
         outputfile = open(batchfilename, "w")
         outputfile.write("@echo off" + "\n"
-                         + "robocopy " + source + " " + destination + " " + "/MIR")
+                         + "robocopy '" + source + "' '" + destination + "' " + "/MIR")
         outputfile.close()
 
     # Reads existing batchfile if it exists and stores the source and destination directories in the variable previous
@@ -54,9 +54,7 @@ class BatchFile:
                 i=1
                 for line in inputfile:
                     if line.startswith("robocopy"):
-                        line = re.sub('robocopy ', '', line)
-                        line = re.sub('/MIR', '', line)
-                        self.previousfolders = line.split()
+			self.previousfolders = [line.split("'")[1], line.split("'")[3]]
                         # print self.previousfolders
                 i+=1
                 inputfile.close()

--- a/MirrorFolders.py
+++ b/MirrorFolders.py
@@ -1,5 +1,5 @@
 __author__ = 'Jason Maderski'
-__date__ = '10-08-15'
+__date__ = '10-07-16'
 from Tkinter import *
 import tkFileDialog
 import os.path
@@ -40,8 +40,8 @@ class BatchFile:
     # Creates a batch file that uses the built in windows tool robocopy
     def writeBatchFile(self, batchfilename, source, destination):
         outputfile = open(batchfilename, "w")
-        outputfile.write("@echo off" + "\n"
-                         + "robocopy '" + source + "' '" + destination + "' " + "/MIR")
+        outputfile.write('@echo off' + '\n'
+                         + 'robocopy "' + source + '" "' + destination + '" ' + '/MIR')
         outputfile.close()
 
     # Reads existing batchfile if it exists and stores the source and destination directories in the variable previous
@@ -54,7 +54,7 @@ class BatchFile:
                 i=1
                 for line in inputfile:
                     if line.startswith("robocopy"):
-			self.previousfolders = [line.split("'")[1], line.split("'")[3]]
+			self.previousfolders = [line.split('"')[1], line.split('"')[3]]
                         # print self.previousfolders
                 i+=1
                 inputfile.close()


### PR DESCRIPTION
Folder names including whitespaces like _Shared pictures_ now are recognized 
